### PR TITLE
Twitter account configuration fixed

### DIFF
--- a/themes/persona-color/_config.yml
+++ b/themes/persona-color/_config.yml
@@ -3,7 +3,7 @@
 photo: /images/IGGG_l.png
 
 email:
-twitter: "@IGGGorg"
+twitter: "IGGGorg"
 facebook:
 googleplus:
 github: IGGG


### PR DESCRIPTION
atmark on Twitter URI is unnecessary.

ex) twitter.com/@username -> twitter.com/username
